### PR TITLE
Removed hi5 from securityjourney.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ Periodic cyber security newsletters that capture the latest news, summaries of c
 
 - [IT Security Weekend Catch Up](https://badcyber.com/) - Every week BadCyber [(@badcybercom)](https://twitter.com/badcybercom) put together a curated list of all important security news in one place.
 
-- [<hi/5>](https://info.securityjourney.com/hi5signup) - Every week [@SecurityJourney](https://twitter.com/SecurityJourney) sends you five carefully curated application security articles.
-
 
 ## Twitter Lists
 


### PR DESCRIPTION
Removed https://info.securityjourney.com/hi5signup as it's returning a 404 and no other links found for that resource