### PR TITLE
Adding the GRC Engineer newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Periodic cyber security newsletters that capture the latest news, summaries of c
 
 - [Security, Funded](https://www.returnonsecurity.com/) - Get the free newsletter recapping investing in the cybersecurity and privacy space delivered weekly to your inbox - Mike Privette [(@mikepsecuritee)](https://twitter.com/mikepsecuritee)
 
+- [GRC Engineer](https://grcengineer.com) - The weekly newsletter engineering the future of the security GRC field, where leaders from the biggest tech companies improve their GRC programs - Ayoub Fandi
+
 - [RTCSec Newsletter](https://www.rtcsec.com/newsletter/) - A free monthly newsletter bringing you commentary and news around VoIP and WebRTC security. Covers both defensive and offensive security as they relate to Real-time Communications. Prepared by Sandro Gauci [(@sandrogauci)](https://twitter.com/sandrogauci).
 
 - [Politico Weekly Cybersecurity](https://www.politico.com/newsletters/weekly-cybersecurity) - Delivered every Monday by 10 a.m., Weekly Cybersecurity examines the latest news in cybersecurity policy and politics. 


### PR DESCRIPTION
PR to add the GRC Engineer newsletter which is followed by GRC leadership from over 200 of the Fortune 500 companies and execs from all tech companies.