### PR TITLE
Add defend.network (News Newsletters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Periodic cyber security newsletters that capture the latest news, summaries of c
 
 - [The CyberSecurity Club](https://thecybersecurityclub.beehiiv.com/) - Provides a short summary on all the key topics you may have missed for the week, covering threat intelligence, cybersecurity trends & insights, regulatory developments and vulnerability news.
 
+- [defend.network Daily Briefing](https://defend.network) - AI-generated daily cybersecurity threat briefings structured by threat type, industry, and severity, with weekly vulnerability reports and remediation steps. Free, no signup required — [RSS feed](https://defend.network/feed.xml).
+
 - [TLDR Information Security](https://tldr.tech/infosec) - A daily newsletter delivering the latest news, research, and tools.
 
 - [Vulnerable U](https://vulnu.mattjay.com/) - A weekly security newsletter "building resilience" - by Matt Johansen ([@mattjay](https://twitter.com/mattjay))

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Periodic cyber security newsletters that capture the latest news, summaries of c
 
 - [IT Security Weekend Catch Up](https://badcyber.com/) - Every week BadCyber [(@badcybercom)](https://twitter.com/badcybercom) put together a curated list of all important security news in one place.
 
+- [defend.network](https://defend.network/) - Free daily cyber threat briefings and weekly vulnerability reports, with every CVE verified against NVD and CISA KEV.
+
 ## LinkedIn Groups:
 
 - Artificial Intelligence Security - https://www.linkedin.com/groups/14545517/


### PR DESCRIPTION
Adds **defend.network** to News Newsletters — a free daily cyber threat briefing and weekly vulnerability report, with every CVE verified against NVD and CISA KEV. Site: https://defend.network/ (free email subscribe available).