### PR TITLE
Add defend.network (News Newsletters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Periodic cyber security newsletters that capture the latest news, summaries of c
 
 - [IT Security Weekend Catch Up](https://badcyber.com/) - Every week BadCyber [(@badcybercom)](https://twitter.com/badcybercom) put together a curated list of all important security news in one place.
 
+- [defend.network](https://defend.network/) - Free daily cyber threat briefings and weekly vulnerability reports, with every CVE verified against NVD and CISA KEV.
+
 ## LinkedIn Groups:
 
 - Artificial Intelligence Security - https://www.linkedin.com/groups/14545517/


### PR DESCRIPTION
Adds **defend.network** to News Newsletters — a free daily cyber threat briefing and weekly vulnerability report, with every CVE verified against NVD and CISA KEV. Site: https://defend.network/ (free email subscribe available).