### PR TITLE
Add HoneyLabs Weekly Threat Report to Niche Newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Periodic cyber security newsletters that capture the latest news, summaries of c
 - [Venture in Security](https://ventureinsecurity.net/) - A free weekly newsletter about the business side of security (startups, ecosystem, venture capital, investing, markets etc.)
 
 - [MI-One by Metron Security](https://hub.metronlabs.com/newsletter/) - It's your exclusive monthly peek into the inner world of security system integrations and automation.
+
+- [HoneyLabs Weekly Threat Report](https://honeylabs.net/blog) - A weekly report generated from a live honeypot network: port movers, KEV and recent CVE probes being exploited in the wild, attack paths to grep your own logs for, and captured malware. Free by email or [RSS](https://honeylabs.net/blog/rss.xml).
   
 ## News Newsletters 
 


### PR DESCRIPTION
Adds the HoneyLabs Weekly Threat Report to the Niche Newsletters section.

It is a weekly report generated every Monday from a live honeypot sensor network: which ports moved week over week, KEV and recent CVE exploit probes with how many distinct IPs are scanning for each, the URL paths defenders should grep their own access logs for, and malware captured by the sensors (VirusTotal-linked hashes). Every number links to a live, freely queryable view.

Free by email (subscribe on the blog page) or RSS: https://honeylabs.net/blog/rss.xml
Current issue: https://honeylabs.net/blog/weekly-threat-report-2026-06-29