### PR TITLE
Add Darkmoon (autonomous pentest, AD + Kubernetes + web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Periodic cyber security newsletters that capture the latest news, summaries of c
 
 - [The Cloud Security Reading List](https://cloudseclist.com/past-issues/) - A low volume newsletter (delivered once per week) that highlights security-related news focused on the cloud native landscape, hand curated by Marco Lancini ([@lancinimarco](https://twitter.com/lancinimarco)).
 
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Autonomous AI pentesting platform (GPL-3.0) covering web, AD and Kubernetes, where the LLM never sees real IPs or credentials (local privacy gateway).
 - [This Week in 4n6](https://thisweekin4n6.com/) - A collection of everything that happens on a weekly basis in the Digital Forensics and - Incident Response community - Phill Moore ([@phillmoore](https://twitter.com/phillmoore)).
 
 - [Blockchain Threat Intelligence](https://www.blockthreat.io/) - A weekly, independent newsletter to capture the latest security news, tools, events, vulnerabilities, and threats in the cryptocurrency landscape - Peter Kacherginsky [(@\_iphelix)](https://twitter.com/_iphelix).


### PR DESCRIPTION
Nice list. Suggesting Darkmoon, a self-hosted GPL-3.0 autonomous pentest platform (web, AD, Kubernetes, API) with an evidence trail on every finding: https://github.com/ASCIT31/Dark-Moon

Full disclosure: this is ours; happy to reword or drop it.