### PR TITLE
Add GitHub Trends Watch to Niche Newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Periodic cyber security newsletters that capture the latest news, summaries of c
 
 - [MI-One by Metron Security](https://hub.metronlabs.com/newsletter/) - It's your exclusive monthly peek into the inner world of security system integrations and automation.
   
+- [GitHub Trends Watch](https://github.com/zuwasi/GitHub-Trends-Watch) - A self-hosted, cross-platform GitHub trends newsletter generator that monitors GitHub Trending on a configurable schedule, classifies repositories with a dedicated security category, scores growth, maturity, community, and heuristic security signals, and uses a locally installed AI coding agent to produce an illustrated HTML report delivered by email — filterable by language, stars, growth, and keywords to create a security-focused trending-project digest.
+
 ## News Newsletters 
 
 - [The CyberSecurity Club](https://thecybersecurityclub.beehiiv.com/) - Provides a short summary on all the key topics you may have missed for the week, covering threat intelligence, cybersecurity trends & insights, regulatory developments and vulnerability news.


### PR DESCRIPTION
﻿## What is GitHub Trends Watch?

[GitHub Trends Watch](https://github.com/zuwasi/GitHub-Trends-Watch) is a self-hosted, cross-platform GitHub trends newsletter generator (MIT-licensed, Python desktop app). It monitors GitHub Trending on a configurable schedule (daily/weekly/monthly), scrapes and filters repositories by language, stars, growth, and keywords, then uses a locally installed AI coding agent (Amp, Claude Code, Gemini CLI, Codex, Aider, etc.) to produce an illustrated HTML report delivered by email.

## Why it fits this list

The tool has a dedicated **security lens** that makes it a good fit for a security newsletters list:

- **Dedicated Security category** — the rating engine classifies repositories into categories including a Security category keyed on terms like vulnerability, CVE, exploit, pentesting, SIEM, encryption, authentication, SBOM, malware, ransomware, and zero-day.
- **Security scoring** — every repository receives a heuristic security score based on maturity, fork scrutiny, and contributor diversity, contributing 15 percent of the overall ranking.
- **Keyword filtering** — users can use include/exclude keyword filters (e.g. security, CVE, SBOM, pentest) to turn the general trends feed into a security-focused newsletter.
- **AI security assessment** — the AI report prompt explicitly requests a security assessment covering licensing, possible security concerns, and maturity indicators for each trending repository.

## What this PR changes

Adds one bullet entry to the **Niche Newsletters** section of README.md, following the existing format (linked name, URL, concise description). No other content is modified.

Happy to adjust the wording or category placement if you'd prefer it under News Newsletters instead.
